### PR TITLE
feat(app-context): Add new aggregator class AppContext to separate Core and CLI logic

### DIFF
--- a/src/app/context.py
+++ b/src/app/context.py
@@ -1,0 +1,26 @@
+from logging import Logger
+
+from app.session import Session
+from engine.exchange import Exchange
+
+
+class AppContext:
+    """Keeps track of the exchange, the current active user, and of the logger
+
+    Attributes:
+      session (Session): Currently active user session.
+      exchange (Exchange): The stock Exchange.
+      logger (Logger): The logger to log user's actions.
+    """
+
+    def __init__(self, session: Session, exchange: Exchange, logger: Logger):
+        """Instantiate AppContext class
+
+        Args:
+        session (Session): Currently active user session.
+        exchange (Exchange): The stock Exchange.
+        logger (Logger): The logger to log user's actions.
+        """
+        self.session = session
+        self.exchange = exchange
+        self.logger = logger

--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -1,5 +1,5 @@
 from typing import List, Callable, Optional
-import logging
+
 from .commands import (
     do_next,
     do_place_order,
@@ -9,10 +9,33 @@ from .commands import (
     do_portfolio,
     do_login,
     do_logout,
+    do_help,
 )
-from engine.exchange import Exchange
 
-from app.session import Session
+from app.context import AppContext
+
+from view.render import display_welcome
+
+import functools
+
+
+def log_command_factory(logger):
+    """
+    Returns a decorator that will log using the supplied `logger`.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            cmd = fn.__name__.replace("do_", "").upper()
+            logger.info("%s command received: args=%r, kwargs=%r", cmd, args, kwargs)
+            result = fn(*args, **kwargs)
+            logger.info("%s command processed", cmd)
+            return result
+
+        return wrapper
+
+    return decorator
 
 
 class CLI:
@@ -37,18 +60,12 @@ class CLI:
         ['next', 'buy', 'sell', 'match', 'status']
     """
 
-    def __init__(
-        self,
-        exchange: Exchange,
-        logger: logging.Logger,
-    ):
+    def __init__(self, context: AppContext):
         """
         Initialize the CLI with its core dependencies and command map.
 
         Args:
-            exchange (Exchange): the market exchange instance for price and order operations.
-            trader (Trader): the trader instance representing the user.
-            logger (logging.Logger): logger used to record command execution.
+            context (AppContext): Current application context.
 
         Examples:
         >>> from logging_config import setup_logger
@@ -59,38 +76,50 @@ class CLI:
         >>> isinstance(cli, CLI)
         True
         """
-        self.exchange = exchange
-        self.session = Session(exchange.traders)
-        self.logger = logger
+        self.context = context
 
-        HELP_MENU = """
-    login      — Authenticate using your Trader ID
-    logout     - Log out the trader
-    help       — Display this menu
-    next       — Refresh market data
-    match      — Execute order matching
-    portfolio  — View your portfolio holdings and P&L
-    status     — Show pending orders
-    buy        — Place a buy order
-    sell       — Place a sell order
-    quit       — Exit the terminal
-    """
+        wrap = log_command_factory(self.context.logger)
+
+        # --- helper factories ---
+        def _no_args(fn):
+            """Wrap a command fn(ctx) → None"""
+
+            @functools.wraps(fn)
+            def handler(_args=None):
+                return fn(self.context)
+
+            return wrap(handler)
+
+        def _with_args(fn):
+            """Wrap a command fn(ctx, args) → None"""
+
+            @functools.wraps(fn)
+            def handler(args=None):
+                return fn(self.context, args or [])
+
+            return wrap(handler)
+
+        def _with_side(side):
+            """Special factory for buy/sell which need (ctx, side, args)"""
+
+            @functools.wraps(do_place_order)
+            def handler(args=None):
+                return do_place_order(self.context, side, args or [])
+
+            return wrap(handler)
 
         # map command strings to handler callables
-        self.commands: dict[str, Callable[[Optional[List[str]]], None]] = {
-            "login": lambda args=[]: do_login(self.session, args),
-            "logout": lambda args=None: do_logout(self.session),
-            "next": lambda args=None: do_next(self.exchange),
-            "buy": lambda args=[]: do_place_order(
-                self.exchange, self.session, "buy", args
-            ),
-            "sell": lambda args=[]: do_place_order(
-                self.exchange, self.session, "sell", args
-            ),
-            "match": lambda args=[]: do_match(self.exchange, args),
-            "status": lambda args=None: do_status(self.exchange),
-            "portfolio": lambda args=None: do_portfolio(self.exchange, self.session),
-            "help": lambda args=None: print(HELP_MENU),
+        # --- build the dispatch table ---
+        self.commands: dict[str, Callable] = {
+            "login": _with_args(do_login),
+            "logout": _no_args(do_logout),
+            "next": _no_args(do_next),
+            "buy": _with_side("buy"),
+            "sell": _with_side("sell"),
+            "match": _with_args(do_match),
+            "status": _no_args(do_status),
+            "portfolio": _no_args(do_portfolio),
+            "help": _no_args(do_help),
         }
 
     def run(self):
@@ -113,6 +142,8 @@ class CLI:
         >>> # This would start an interactive loop
         >>> cli.run()  # doctest: +SKIP
         """
+
+        display_welcome()
         while True:
             try:
                 raw = input(">>> ")
@@ -126,7 +157,7 @@ class CLI:
 
             cmd, *args = raw.split()
             if cmd in ["quit", "exit"]:
-                log_quit()
+                log_quit(self.context)
                 break
 
             handler = self.commands.get(cmd)
@@ -135,5 +166,3 @@ class CLI:
                 handler(args if args else None)
             else:
                 print("Unknown command. Please try again.")
-
-    # TODO: move to a Session class so the login is separate from CLI and can be used with other GUI

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1,20 +1,21 @@
-from cli.validation import parse_order, validate_symbol
-from view.render import display_prices, display_portfolio, display_pending_orders
-from engine.exchange import Exchange
-from engine.trader import Trader
-import logging
-from logging_config import LOG_NAME
-
 from typing import List
 
+from engine.exchange import Exchange
+
 from app.session import Session
+from app.context import AppContext
 
-logger = logging.getLogger(LOG_NAME)
+from cli.validation import parse_order, validate_symbol
+
+from view.render import (
+    display_prices,
+    display_portfolio,
+    display_pending_orders,
+    display_help_menu,
+)
 
 
-def handle_order(
-    exchange: Exchange, session: Session, order_type: str, args: list[str]
-):
+def handle_order(context: AppContext, order_type: str, args: list[str]):
     """
     Handle a buy or sell order: parse args, validate and enqueue the order, then show portfolio.
 
@@ -31,6 +32,7 @@ def handle_order(
         Cash balance: $1000.0
         Holdings: {}
     """
+    exchange, session, logger = context.exchange, context.session, context.logger
 
     try:
         trader = session.require_active()
@@ -67,31 +69,7 @@ def handle_order(
     print(f"\nOrder placed for {symbol}.\n")
 
 
-def log_command(fn):
-    """
-    Decorator: log command invocation and completion at INFO level.
-
-    Examples:
-        >>> @log_command
-        ... def my_func(x):
-        ...     return x + 1
-        >>> my_func(2)
-        3
-    """
-
-    def wrapper(*args, **kwargs):
-        cmd = fn.__name__.replace("do_", "").upper()
-
-        logger.info("%s command received: args=%r", cmd, args or kwargs)
-        result = fn(*args, **kwargs)
-        logger.info("%s command processed", cmd)
-        return result
-
-    return wrapper
-
-
-@log_command
-def do_next(exchange: Exchange):
+def do_next(context: AppContext):
     """
     Advance the market by one tick and display prices & portfolio.
 
@@ -104,16 +82,15 @@ def do_next(exchange: Exchange):
         >>> do_next(ex, tr) is None
         True
     """
+    exchange = context.exchange
+
     exchange.process_tick()
     print()
     display_prices(exchange)
     print()
 
 
-@log_command
-def do_place_order(
-    exchange: Exchange, session: Session, order_type: str, args: List[str]
-):
+def do_place_order(context: AppContext, order_type: str, args: List[str]):
     """
     Enqueue a buy/sell order and log details if valid.
 
@@ -127,9 +104,11 @@ def do_place_order(
         True
     """
 
+    logger = context.logger
+
     symbol, qty, price = parse_order(args)
 
-    handle_order(exchange, session, order_type, args)
+    handle_order(context, order_type, args)
 
     # only log if parsing succeeded
     if None not in (symbol, qty, price):
@@ -142,8 +121,7 @@ def do_place_order(
         )
 
 
-@log_command
-def do_match(exchange: Exchange, args: List[str]):
+def do_match(context: AppContext, args: List[str]):
     """
     Attempt to match orders for a given symbol and display results.
 
@@ -154,6 +132,8 @@ def do_match(exchange: Exchange, args: List[str]):
         >>> do_match(ex, ['AAPL'])
         No trades yet
     """
+    logger, exchange = context.logger, context.exchange
+
     if not args or len(args) != 1:
         print("\nUsage: match <SYMBOL>\n")
         logger.warning(
@@ -185,8 +165,9 @@ def do_match(exchange: Exchange, args: List[str]):
         print()
 
 
-@log_command
-def do_portfolio(exchange: Exchange, session: Session):
+def do_portfolio(context: AppContext):
+
+    session, logger, exchange = context.session, context.logger, context.exchange
 
     try:
         trader = session.require_active()
@@ -203,8 +184,7 @@ def do_portfolio(exchange: Exchange, session: Session):
     display_portfolio(exchange, exchange.traders[trader.trader_id])
 
 
-@log_command
-def do_status(exchange: Exchange):
+def do_status(context: AppContext):
     """
     Display pending orders and the trader's portfolio.
 
@@ -219,6 +199,8 @@ def do_status(exchange: Exchange):
         Cash balance: $1000.0
         Holdings: {}
     """
+    logger, exchange = context.logger, context.exchange
+
     pending = sum(
         len(book._buy_heap) + len(book._sell_heap)
         for book in exchange.order_books.values()
@@ -231,8 +213,9 @@ def do_status(exchange: Exchange):
     logger.info("STATUS viewed: %d pending orders", pending)
 
 
-@log_command
-def do_login(session: Session, args):
+def do_login(context: AppContext, args):
+    logger, session = context.logger, context.session
+
     if args is None or len(args) != 1 or args[0].isnumeric() == False:
         print("\nUsage: login <trader_id>\n")
         logger.warning(
@@ -259,8 +242,9 @@ def do_login(session: Session, args):
         return
 
 
-@log_command
-def do_logout(session: Session):
+def do_logout(context: AppContext):
+    session, logger = context.session, context.logger
+
     try:
         session.logout()
         print("\nYou have successfully logged out.\n")
@@ -273,7 +257,11 @@ def do_logout(session: Session):
         )
 
 
-def log_quit():
+def do_help():
+    display_help_menu()
+
+
+def log_quit(context: AppContext):
     """
     Print goodbye and log shutdown.
 
@@ -281,5 +269,7 @@ def log_quit():
         >>> log_quit() # doctest: +NORMALIZE_WHITESPACE
         Thank you for using York Stock Exchange.
     """
+    logger = context.logger
+
     print("\nThank you for using York Stock Exchange.")
     logger.info("York Stock Exchange CLI shutting down")

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,18 @@
+import argparse
+from datetime import timedelta
+from logging_config import setup_logger
+
 from engine.exchange import Exchange
+from engine.order import Order
 from engine.trader import Trader
 from engine.stock import Stock
 from engine.position import Position
 from engine.market_simulator import MarketSimulator
-from view.render import display_portfolio
-from cli.cli import CLI
-from engine.order import Order
 
-import argparse
-from datetime import timedelta
-from logging_config import setup_logger
-from logging import Logger
+from cli.cli import CLI
+
+from app.context import AppContext
+from app.session import Session
 
 # Dummy initial prices for Day 3 CLI setup
 MARKET_DATA = {
@@ -24,26 +26,8 @@ MARKET_DATA = {
 }
 
 
-def manual_loop(exchange: Exchange, logger: Logger):
-    WELCOME_MESSAGE = """
-YORK STOCK EXCHANGE TERMINAL
-
-Please log in with your Trader ID before issuing any other commands.
-
-    login      — Authenticate using your Trader ID
-    help       — Display this menu
-    next       — Refresh market data
-    match      — Execute order matching
-    portfolio  — View your portfolio holdings and P&L
-    status     — Show pending orders
-    buy        — Place a buy order
-    sell       — Place a sell order
-    quit       — Exit the terminal
-"""
-
-    print(WELCOME_MESSAGE)
-
-    CLI(exchange, logger).run()
+def manual_loop(context: AppContext):
+    CLI(context).run()
 
 
 def main():
@@ -92,7 +76,7 @@ def main():
             steps = int(args.auto)  # the provided number
         sim.run(steps)
     else:
-        manual_loop(exchange, logger)
+        manual_loop(context=AppContext(Session(exchange.traders), exchange, logger))
 
 
 if __name__ == "__main__":

--- a/src/view/render.py
+++ b/src/view/render.py
@@ -1,6 +1,25 @@
 from engine.exchange import Exchange
 from engine.trader import Trader
 
+HELP_MENU = """
+    login      — Authenticate using your Trader ID
+    logout     - Log out the trader
+    help       — Display this menu
+    next       — Refresh market data
+    match      — Execute order matching
+    portfolio  — View your portfolio holdings and P&L
+    status     — Show pending orders
+    buy        — Place a buy order
+    sell       — Place a sell order
+    quit       — Exit the terminal
+    """
+
+WELCOME_MESSAGE = f"""
+YORK STOCK EXCHANGE TERMINAL
+
+Please log in with your Trader ID before issuing any other commands.
+{HELP_MENU}"""
+
 
 def display_prices(exchange: Exchange):
     """
@@ -95,3 +114,13 @@ def display_pending_orders(exchange: Exchange):
             )
             print(message)
     print()
+
+
+def display_welcome():
+
+    print(WELCOME_MESSAGE)
+
+
+def display_help_menu():
+
+    print(HELP_MENU)

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -9,6 +9,9 @@ from cli.commands import (
     do_status,
 )
 
+from app.context import AppContext
+from app.session import Session
+
 from engine.exchange import Exchange
 from engine.order import Order
 from engine.trader import Trader
@@ -31,14 +34,18 @@ def test_validate_symbol_unknown(sample_market, caplog):
     assert "BUY command usage error" in caplog.text
 
 
-def test_handle_order_invalid_args_num(sample_market: Exchange, caplog, trader: Trader):
+def test_handle_order_invalid_args_num(
+    sample_market: Exchange, caplog, trader: Trader, test_context: AppContext
+):
     caplog.set_level(logging.WARNING)
+
+    session = Session(sample_market.traders)
+    session.login(trader.trader_id)
 
     o = Order(trader_id=trader.trader_id, symbol="AAPL", order_type="buy", quantity=42)
 
     handle_order(
-        exchange=sample_market,
-        trader=trader,
+        test_context,
         order_type=o.order_type,
         args=["AAPL", "42"],
     )
@@ -47,7 +54,7 @@ def test_handle_order_invalid_args_num(sample_market: Exchange, caplog, trader: 
     assert len(sample_market.order_books["AAPL"]._buy_heap) == 0
 
 
-def test_handle_order_adds_order(sample_market: Exchange, trader: Trader):
+def test_handle_order_adds_order(test_context: AppContext, trader: Trader):
 
     o = Order(
         trader_id=trader.trader_id,
@@ -58,38 +65,43 @@ def test_handle_order_adds_order(sample_market: Exchange, trader: Trader):
     )
 
     handle_order(
-        exchange=sample_market,
-        trader=trader,
+        test_context,
         order_type=o.order_type,
         args=["AAPL", "42", "100.00"],
     )
 
-    assert len(sample_market.order_books["AAPL"]._buy_heap) == 1
+    assert len(test_context.exchange.order_books["AAPL"]._buy_heap) == 1
 
 
-def test_do_next_updates_prices(sample_market: Exchange):
+def test_do_next_updates_prices(test_context: AppContext):
+    ex = test_context.exchange
     old_p = 100.0
-    do_next(sample_market)
-    assert sample_market.market_data.get("AAPL").price != old_p
+    do_next(test_context)
+    assert ex.market_data.get("AAPL").price != old_p
 
 
-def test_do_next_updates_time(sample_market: Exchange):
-    old_time = sample_market.current_time
-    do_next(sample_market)
-    assert sample_market.current_time != old_time
+def test_do_next_updates_time(test_context: AppContext):
+    ex = test_context.exchange
+
+    old_time = test_context.exchange.current_time
+    do_next(test_context)
+    assert ex.current_time != old_time
 
 
-def test_do_place_order_places_order(sample_market: Exchange, trader: Trader):
-    do_place_order(sample_market, trader, "buy", ["AAPL", "1", "100"])
+def test_do_place_order_places_order(test_context: AppContext, trader: Trader):
+    ex = test_context.exchange
 
-    assert sample_market.order_books.get("AAPL").buy_size() == 1
-    assert sample_market.order_books.get("AAPL").peek_best_buy().quantity == 1
-    assert sample_market.order_books.get("AAPL").peek_best_buy().limit_price == 100.00
+    do_place_order(test_context, "buy", ["AAPL", "1", "100"])
+
+    assert ex.order_books.get("AAPL").buy_size() == 1
+    assert ex.order_books.get("AAPL").peek_best_buy().quantity == 1
+    assert ex.order_books.get("AAPL").peek_best_buy().limit_price == 100.00
 
 
-def test_do_match_invalid_args_num(sample_market: Exchange, caplog):
+def test_do_match_invalid_args_num(test_context: AppContext, caplog):
+
     caplog.set_level(logging.WARNING)
 
-    do_match(sample_market, [])
+    do_match(test_context, [])
 
     assert "MATCH command usage error" in caplog.text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 import pytest
 
+import logging
+
 from engine.exchange import Exchange
 from engine.trader import Trader
 from engine.stock import Stock
+
+from app.session import Session
+from app.context import AppContext
 
 
 @pytest.fixture
@@ -23,3 +28,18 @@ def trader2(sample_market: Exchange):
     tr = Trader(trader_id=2, starting_balance=1_000_000)
     sample_market.register_trader(tr)
     return tr
+
+
+@pytest.fixture
+def test_context(sample_market: Exchange, trader: Trader, caplog):
+    session = Session(sample_market.traders)
+    session.login(trader.trader_id)
+
+    test_logger = logging.getLogger("test")
+    test_logger.propagate = True
+    test_logger.setLevel(logging.INFO)
+
+    # 2) tell caplog to capture that logger at INFO
+    caplog.set_level(logging.INFO, logger="test")
+
+    return AppContext(exchange=sample_market, session=session, logger=test_logger)


### PR DESCRIPTION
# Changes

## `AppContext` class
Instead of `CLI` class directly owning `Exchange` and `Logger`, now both of them are self-contained in a `AppContext` class. This allows the clear separation between the logic reserved for `CLI`, and the general data about the app that must be separated from 